### PR TITLE
Replace map(lambda with generator expression

### DIFF
--- a/Python/06. Itertools/007. Maximize It!.py
+++ b/Python/06. Itertools/007. Maximize It!.py
@@ -6,5 +6,5 @@ from itertools import product
 
 k, m = map(int, input().split())
 n = (list(map(int, input().split()))[1:] for _ in range(k))
-results = map(lambda x: sum(i**2 for i in x) % m, product(*n))
+results = (sum(i**2 for i in x) % m for x in product(*n))
 print(max(results))


### PR DESCRIPTION
Generally, `map` and `lambda` should only be used if a function is named. Lambda is longer and less readable, than a generator expression.